### PR TITLE
Make *log-stream* a stream

### DIFF
--- a/vom.lisp
+++ b/vom.lisp
@@ -69,7 +69,7 @@
    T as the default (used if logging from a package that hasn't been
    configured).")
 
-(defvar *log-stream* t
+(defvar *log-stream* (make-synonym-stream 'cl:*standard-output*)
   "Holds the default stream we're logging to.")
 
 (defvar *log-hook*


### PR DESCRIPTION
This is a pedantic change. Most stream functions accept a stream designator as well (which includes t and nil) and the couple that don't (write-byte/close/file-position) don't make much sense in this case. But why be practically correct when you can be correct :sweat_smile: 