### PR TITLE
Flush output after logging.

### DIFF
--- a/vom.lisp
+++ b/vom.lisp
@@ -137,7 +137,8 @@
         (dolist (stream log-streams)
           (write-sequence logline (if (eq stream t)
                                       cl:*standard-output*
-                                      stream)))))))
+                                      stream))
+          (cl:finish-output stream))))))
 
 (defmacro define-level (name level-value)
   "Define a log level."


### PR DESCRIPTION
It is important that logging messages are flushed in a timely manner. If
messages are small, they could remain in the buffer for quite a while
before they are automatically flushed, so explicitly flush them after each
write.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/orthecreedence/vom/2)
<!-- Reviewable:end -->
