### PR TITLE
Fix: compiler notes

### DIFF
--- a/vom.lisp
+++ b/vom.lisp
@@ -10,6 +10,7 @@
                 #:eval-when
                 #:eval
                 #:lambda #:defun #:multiple-value-list #:defmacro
+		#:declaim #:function
                 #:return-from
                 #:defvar #:defparameter
                 #:declare #:optimize #:type #:ignore
@@ -77,6 +78,7 @@
 (defvar *log-stream* (make-synonym-stream 'cl:*standard-output*)
   "Holds the default stream we're logging to.")
 
+(declaim (function *log-hook* *log-formatter*))
 (defvar *log-hook*
   (lambda (log-level package-keyword package-log-level)
     (declare (ignore log-level package-keyword package-log-level))


### PR DESCRIPTION
Declaim `*log-formatter*` and `*log-hook*` as
function to avoid the compiler note:
unable to optimize away possible call to
`fdefinition` at runtime because dynamic
variable is not known to be a function

The compiler note appears when loading `vom` 
with `asdf:load-system`